### PR TITLE
Add host_ip in properties section

### DIFF
--- a/kub/test/local-blueprint.yaml
+++ b/kub/test/local-blueprint.yaml
@@ -22,7 +22,9 @@ node_types:
       ssh_port:
         description: ssh port.  defaults to 22
         default: 22
-      
+      host_ip:
+        description: host ip
+        default: ''
 
   cloudify.kubernetes.master:
     derived_from: cloudify.kubernetes.base


### PR DESCRIPTION
Add host_ip in to properties section of cloudify.kubernetes.base in local-blueprint.yaml
